### PR TITLE
fix: rsyslog rotate execution for Debian 12 and later

### DIFF
--- a/templates/logrotate/etc/logrotate.d/10-proxyaai.conf.j2
+++ b/templates/logrotate/etc/logrotate.d/10-proxyaai.conf.j2
@@ -13,7 +13,7 @@
         sharedscripts
         postrotate
                 sleep $(shuf -i5-60 -n1) && docker restart krb-exchanger
-                invoke-rc.d rsyslog rotate > /dev/null
+                /usr/lib/rsyslog/rsyslog-rotate
         endscript
 }
 {% endif %}
@@ -33,7 +33,7 @@
         sharedscripts
         postrotate
                 sleep $(shuf -i5-60 -n1) && docker restart ga4gh_broker
-                invoke-rc.d rsyslog rotate > /dev/null
+                /usr/lib/rsyslog/rsyslog-rotate
         endscript
 }
 {% endif %}
@@ -53,7 +53,7 @@
         sharedscripts
         postrotate
                 sleep $(shuf -i5-60 -n1) && docker restart mitreid-tomcat
-                invoke-rc.d rsyslog rotate > /dev/null
+                /usr/lib/rsyslog/rsyslog-rotate
         endscript
 }
 {% endif %}
@@ -73,7 +73,7 @@
         sharedscripts
         postrotate
                 sleep $(shuf -i5-60 -n1) && docker restart simplesamlphp
-                invoke-rc.d rsyslog rotate > /dev/null
+                /usr/lib/rsyslog/rsyslog-rotate
         endscript
 }
 
@@ -92,7 +92,7 @@
         sharedscripts
         postrotate
                 sleep $(shuf -i5-60 -n1) && docker restart reverseproxy
-                invoke-rc.d rsyslog rotate > /dev/null
+                /usr/lib/rsyslog/rsyslog-rotate
         endscript
 }
 
@@ -111,7 +111,7 @@
         sharedscripts
         postrotate
                 sleep $(shuf -i5-60 -n1) && docker restart exabgp
-                invoke-rc.d rsyslog rotate > /dev/null
+                /usr/lib/rsyslog/rsyslog-rotate
         endscript
 }
 {% endif %}
@@ -132,7 +132,7 @@
         sharedscripts
         postrotate
                 sleep $(shuf -i5-60 -n1) && docker restart {{ pgbouncer }}
-                invoke-rc.d rsyslog rotate > /dev/null
+                /usr/lib/rsyslog/rsyslog-rotate
         endscript
 }
 {% endfor %}

--- a/templates/logrotate/etc/logrotate.d/60-mfa.conf.j2
+++ b/templates/logrotate/etc/logrotate.d/60-mfa.conf.j2
@@ -15,6 +15,6 @@
                 docker restart mfapgbouncer
                 docker restart oauth2proxy
                 docker restart oauth2proxymfa
-                invoke-rc.d rsyslog rotate > /dev/null
+                /usr/lib/rsyslog/rsyslog-rotate
         endscript
 }


### PR DESCRIPTION
On Debian 12 and later, rsyslog no longer provides the SysV init script used for log rotation. Rotation is handled via the systemd-compatible helper at `/usr/lib/rsyslog/rsyslog-rotate`, which is also backward compatible with older Debian releases.